### PR TITLE
Issue #1: Fix handling of default options

### DIFF
--- a/lib/capistrano/rsync.rb
+++ b/lib/capistrano/rsync.rb
@@ -5,23 +5,13 @@ require File.expand_path("../rsync/version", __FILE__)
 # private API and internals of Capistrano::Rsync. If you think something should
 # be public for extending and hooking, please let me know!
 
-set :rsync_options, []
-set :rsync_copy, "rsync --archive --acls --xattrs"
-
-# Stage is used on your local machine for rsyncing from.
-set :rsync_stage, "tmp/deploy"
-
-# Cache is used on the server to copy files to from to the release directory.
-# Saves you rsyncing your whole app folder each time.  If you nil rsync_cache,
-# Capistrano::Rsync will sync straight to the release path.
-set :rsync_cache, "shared/deploy"
-
 rsync_cache = lambda do
   cache = fetch(:rsync_cache)
   cache = deploy_to + "/" + cache if cache && cache !~ /^\//
   cache
 end
 
+Rake::Task["load:defaults"].enhance ["rsync:defaults"]
 Rake::Task["deploy:check"].enhance ["rsync:hook_scm"]
 Rake::Task["deploy:updating"].enhance ["rsync:hook_scm"]
 
@@ -40,13 +30,28 @@ task :rsync => %w[rsync:stage] do
 end
 
 namespace :rsync do
+
+  desc "Load rsync default options."
+  task :defaults do
+    set :rsync_options, %w[--recursive --delete --delete-excluded  --exclude .git*]
+    set :rsync_copy, "rsync --archive --acls --xattrs"
+
+    # Stage is used on your local machine for rsyncing from.
+    set :rsync_stage, "tmp/deploy"
+
+    # Cache is used on the server to copy files to from to the release
+    # directory. Saves you rsyncing your whole app folder each time. If you nil
+    # rsync_cache, Capistrano::Rsync will sync straight to the release path.
+    set :rsync_cache, "shared/deploy"
+  end
+
   task :hook_scm do
     Rake::Task.define_task("#{scm}:check") do
-      invoke "rsync:check" 
+      invoke "rsync:check"
     end
 
     Rake::Task.define_task("#{scm}:create_release") do
-      invoke "rsync:release" 
+      invoke "rsync:release"
     end
   end
 


### PR DESCRIPTION
Hi,

i think i found the bug. The handling of default options is wrong. Because of the order the options are loaded rsync.rb overwrites all options that are already defined. Look at https://github.com/capistrano/capistrano/blob/master/lib/capistrano/setup.rb 

Whats why :rsync_options is always en empty array and the rsync command in :rsync will fail.

_Please note i am not a ruby developer and this is completely wrong._
