### PR TITLE
Set current_revision by `git rev-parse --short HEAD`

### DIFF
--- a/lib/capistrano/rsync.rb
+++ b/lib/capistrano/rsync.rb
@@ -71,6 +71,9 @@ namespace :rsync do
 
       checkout = %W[git reset --hard origin/#{fetch(:branch)}]
       Kernel.system *checkout
+
+      last_commit_id = `git rev-parse HEAD`
+      set :current_revision, "#{last_commit_id}".chomp
     end
   end
 

--- a/lib/capistrano/rsync.rb
+++ b/lib/capistrano/rsync.rb
@@ -72,8 +72,7 @@ namespace :rsync do
       checkout = %W[git reset --hard origin/#{fetch(:branch)}]
       Kernel.system *checkout
 
-      last_commit_id = `git rev-parse --short HEAD`
-      set :current_revision, "#{last_commit_id}".chomp
+      set :current_revision, "#{`git rev-parse --short HEAD`}".chomp
     end
   end
 

--- a/lib/capistrano/rsync.rb
+++ b/lib/capistrano/rsync.rb
@@ -72,7 +72,7 @@ namespace :rsync do
       checkout = %W[git reset --hard origin/#{fetch(:branch)}]
       Kernel.system *checkout
 
-      last_commit_id = `git rev-parse HEAD`
+      last_commit_id = `git rev-parse --short HEAD`
       set :current_revision, "#{last_commit_id}".chomp
     end
   end


### PR DESCRIPTION
Missing sha on `revision.log`. so I set current_revision by git command.

current:

``` log
Branch master (at ) deployed as release 20140123030204 by linyows;
```

new:

``` log
Branch master (at f38f86b) deployed as release 20140123030523 by linyows;
```
