### PR TITLE
Use release_roles instead of roles so we only run rsync on nodes we are deploying to

### DIFF
--- a/lib/capistrano/rsync.rb
+++ b/lib/capistrano/rsync.rb
@@ -27,7 +27,7 @@ Rake::Task["deploy:updating"].enhance ["rsync:hook_scm"]
 
 desc "Stage and rsync to the server (or its cache)."
 task :rsync => %w[rsync:stage] do
-  roles(:all).each do |role|
+  release_roles(:all).each do |role|
     user = role.user + "@" if !role.user.nil?
 
     rsync = %w[rsync]
@@ -80,7 +80,7 @@ namespace :rsync do
     next if !fetch(:rsync_cache)
 
     copy = %(#{fetch(:rsync_copy)} "#{rsync_cache.call}/" "#{release_path}/")
-    on roles(:all).each do execute copy end
+    on release_roles(:all).each do execute copy end
   end
 
   # Matches the naming scheme of git tasks.


### PR DESCRIPTION
Capistrano 3.1.0 is using release_roles do identify servers that we actually want to deploy on to.
This fix ensures we only sync code on to servers that we want to release on to (e.g. where no_release != true)
