### PR TITLE
Removes instructions to include capistrano/rsync.rb in the deploy.rb file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,6 @@ Install with:
 gem install capistrano-rsync
 ```
 
-Require it at the top of your `Capfile` (or `config/deploy.rb`):
-```ruby
-require "capistrano/rsync"
-```
-
 Set some `rsync_options` to your liking:
 ```ruby
 set :rsync_options, %w[--recursive --delete --delete-excluded --exclude .git*]


### PR DESCRIPTION
rsync.rb gets loaded automatically by capistrano. Including it in your deploy.rb causes all rsync tasks to be executed twice. This is related to issue #1 74785bd
