### PR TITLE
fix for defaults options overwriting settings

### DIFF
--- a/lib/capistrano/rsync.rb
+++ b/lib/capistrano/rsync.rb
@@ -5,16 +5,25 @@ require File.expand_path("../rsync/version", __FILE__)
 # private API and internals of Capistrano::Rsync. If you think something should
 # be public for extending and hooking, please let me know!
 
-set :rsync_options, []
-set :rsync_copy, "rsync --archive --acls --xattrs"
+fetch(:rsync_options) do
+  set :rsync_options, []
+end
+
+fetch(:rsync_copy) do
+  set :rsync_copy, "rsync --archive --acls --xattrs"
+end
 
 # Stage is used on your local machine for rsyncing from.
-set :rsync_stage, "tmp/deploy"
+fetch(:rsync_stage) do
+  set :rsync_stage, "tmp/deploy"
+end
 
 # Cache is used on the server to copy files to from to the release directory.
 # Saves you rsyncing your whole app folder each time.  If you nil rsync_cache,
 # Capistrano::Rsync will sync straight to the release path.
-set :rsync_cache, "shared/deploy"
+fetch(:rsync_cache) do
+  set :rsync_cache, "shared/deploy"
+end
 
 rsync_cache = lambda do
   cache = fetch(:rsync_cache)


### PR DESCRIPTION
This fixes the problem where the default settings are overriding the user settings. 
I explain in my comment for https://github.com/moll/capistrano-rsync/pull/2 why this was happening. 

Tested to work with capistrano v3.1.0. I now have no issues with deploys. 
