### PR TITLE
Skip git run on target and fill revision correctly

### DIFF
--- a/lib/capistrano/rsync.rb
+++ b/lib/capistrano/rsync.rb
@@ -81,8 +81,6 @@ namespace :rsync do
     end
   end
 
-  after :stage, :set_current_revision
-
   desc "Set current revision into capistrano variable"
   task :set_current_revision do
     Dir.chdir fetch(:rsync_stage) do
@@ -90,6 +88,8 @@ namespace :rsync do
       set(:current_revision, get_current_revision)
     end
   end
+
+  after :stage, :set_current_revision
 
   desc "Copy the code to the releases directory."
   task :release => %w[rsync] do

--- a/lib/capistrano/rsync.rb
+++ b/lib/capistrano/rsync.rb
@@ -41,12 +41,19 @@ end
 
 namespace :rsync do
   task :hook_scm do
+    Rake::Task["#{scm}:check"].clear
     Rake::Task.define_task("#{scm}:check") do
       invoke "rsync:check" 
     end
 
+    Rake::Task["#{scm}:create_release"].clear
     Rake::Task.define_task("#{scm}:create_release") do
       invoke "rsync:release" 
+    end
+
+    Rake::Task["#{scm}:set_current_revision"].clear
+    Rake::Task.define_task("#{scm}:set_current_revision") do
+      p "Revision: #{fetch(:current_revision)}" 
     end
   end
 
@@ -71,6 +78,9 @@ namespace :rsync do
 
       checkout = %W[git reset --hard origin/#{fetch(:branch)}]
       Kernel.system *checkout
+
+      get_current_revision =  %x[git rev-parse HEAD]
+      set(:current_revision, get_current_revision)
     end
   end
 

--- a/lib/capistrano/rsync.rb
+++ b/lib/capistrano/rsync.rb
@@ -41,12 +41,19 @@ end
 
 namespace :rsync do
   task :hook_scm do
+    Rake::Task["#{scm}:check"].clear
     Rake::Task.define_task("#{scm}:check") do
       invoke "rsync:check" 
     end
 
+    Rake::Task["#{scm}:create_release"].clear
     Rake::Task.define_task("#{scm}:create_release") do
       invoke "rsync:release" 
+    end
+
+    Rake::Task["#{scm}:set_current_revision"].clear
+    Rake::Task.define_task("#{scm}:set_current_revision") do
+      # :current_revision was already set during checkout 
     end
   end
 
@@ -72,6 +79,14 @@ namespace :rsync do
       checkout = %W[git reset --hard origin/#{fetch(:branch)}]
       Kernel.system *checkout
     end
+  end
+
+  after :stage, :set_current_revision
+
+  desc "Set current revision into capistrano variable"
+  task :set_current_revision do
+    get_current_revision =  %x[git rev-parse HEAD]
+    set(:current_revision, get_current_revision)    
   end
 
   desc "Copy the code to the releases directory."

--- a/lib/capistrano/rsync/version.rb
+++ b/lib/capistrano/rsync/version.rb
@@ -1,5 +1,5 @@
 module Capistrano
   module Rsync
-    VERSION = "1.0.2"
+    VERSION = "1.0.2a"
   end
 end


### PR DESCRIPTION
Issue description: capistrano 3 tries to run git on target for git:check and git:create_release (which fails since there may be no access to local repo from target system). Also revision version is not passed to target system.
Root cause: Without Rake::Task.clear new task definition is not replacing, but appending new functionality.
Solution: Added clear of git:check, git:create_release and git:set_revision. Fill current_revision capistrano variable after cloning locally
