### PR TITLE
Make no assumptions about :branch

### DIFF
--- a/lib/capistrano/rsync.rb
+++ b/lib/capistrano/rsync.rb
@@ -69,7 +69,7 @@ namespace :rsync do
       update = %W[git fetch --quiet --all --prune]
       Kernel.system *update
 
-      checkout = %W[git reset --hard origin/#{fetch(:branch)}]
+      checkout = %W[git reset --hard #{fetch(:branch)}]
       Kernel.system *checkout
     end
   end


### PR DESCRIPTION
Remove the required 'origin/' prefix to the branch/revision path. This
should allow the use of any revision spec. Filtering on revision spec
should be part of a hook that enforces local developer/team policy.
It shouldn't be cooked into the library.
